### PR TITLE
Major CAN fix

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,6 @@
 {
-    "editor.formatOnSave": true
+    "editor.formatOnSave": true,
+    "files.associations": {
+        "*.tpp": "cpp"
+    }
 }

--- a/lib/Actuator/src/Actuator.cpp
+++ b/lib/Actuator/src/Actuator.cpp
@@ -52,7 +52,7 @@ float Actuator::update_speed(float target_speed) {
  * @return the speed that is set
  */
 float Actuator::set_speed(float set_speed) {
-  odrive->set_state(ACTUATOR_AXIS, 8);
+  odrive->set_state(ACTUATOR_AXIS, ODRIVE_VELOCITY_CONTROL_STATE);
   odrive->set_input_vel(ACTUATOR_AXIS, set_speed, 0);
   current_speed = set_speed;
   return current_speed;

--- a/lib/Actuator/src/Actuator.cpp
+++ b/lib/Actuator/src/Actuator.cpp
@@ -10,7 +10,6 @@
  */
 Actuator::Actuator(OdriveCAN* odrive_in) {
   odrive = odrive_in;
-  commanded_axis_state = odrive->get_axis_state(ACTUATOR_AXIS);
 }
 
 /**
@@ -19,6 +18,7 @@ Actuator::Actuator(OdriveCAN* odrive_in) {
  */
 bool Actuator::init() {
   // Due to CAN interrupt handler weirdness
+  commanded_axis_state = odrive->get_axis_state(ACTUATOR_AXIS);
   return 1;
 }
 
@@ -27,7 +27,9 @@ bool Actuator::init() {
  * @return bool if successful
  */
 bool Actuator::encoder_index_search() {
-  int state = odrive->set_state(ACTUATOR_AXIS, 6);
+  int state =
+      odrive->set_state(ACTUATOR_AXIS, ODRIVE_ENCODER_INDEX_SEARCH_STATE);
+  commanded_axis_state = ODRIVE_ENCODER_INDEX_SEARCH_STATE;
   delayMicroseconds(5 * 1000000);
   if (state == 0)
     return true;
@@ -43,6 +45,10 @@ bool Actuator::encoder_index_search() {
  * @return the current set speed of the actuator
  */
 float Actuator::update_speed(float target_speed) {
+  if (commanded_axis_state == ODRIVE_VELOCITY_CONTROL_STATE &&
+      target_speed == current_speed) {
+    return target_speed;
+  }
   return Actuator::set_speed(target_speed);
 }
 
@@ -52,8 +58,14 @@ float Actuator::update_speed(float target_speed) {
  * @return the speed that is set
  */
 float Actuator::set_speed(float set_speed) {
-  odrive->set_state(ACTUATOR_AXIS, ODRIVE_VELOCITY_CONTROL_STATE);
-  odrive->set_input_vel(ACTUATOR_AXIS, set_speed, 0);
+  int can_error =
+      odrive->set_state(ACTUATOR_AXIS, ODRIVE_VELOCITY_CONTROL_STATE);
+  commanded_axis_state = ODRIVE_VELOCITY_CONTROL_STATE;
+  can_error =
+      (can_error << 1) | odrive->set_input_vel(ACTUATOR_AXIS, set_speed, 0);
+  if (can_error != 0) {
+    Serial.printf("Error Setting Speed (CAN Error %d)\n", can_error);
+  }
   current_speed = set_speed;
   return current_speed;
 }

--- a/lib/Actuator/src/Actuator.cpp
+++ b/lib/Actuator/src/Actuator.cpp
@@ -6,6 +6,7 @@
 
 /**
  * Constructor assigns odrive pointer as class member
+ * @param odrive_in pointer to odrive CAN object
  */
 Actuator::Actuator(OdriveCAN* odrive_in) {
   odrive = odrive_in;
@@ -14,7 +15,7 @@ Actuator::Actuator(OdriveCAN* odrive_in) {
 
 /**
  * Initializes connection to physical odrive
- * Returns bool if successful
+ * @return bool if successful
  */
 bool Actuator::init() {
   // Due to CAN interrupt handler weirdness
@@ -23,21 +24,23 @@ bool Actuator::init() {
 
 /**
  * Instructs Odrive to attempt encoder homing
- * Returns a bool if successful
+ * @return bool if successful
  */
 bool Actuator::encoder_index_search() {
   int state = odrive->set_state(ACTUATOR_AXIS, 6);
-  delayMicroseconds(5*1000000);
-  if (state == 0) return true;
-  else return false;
+  delayMicroseconds(5 * 1000000);
+  if (state == 0)
+    return true;
+  else
+    return false;
 }
 
 // Speed functions
 
 /**
  * If the targeted actuator speed is different than the current speed set it to the updated speed
- * 
- * Returns the current set speed of the actuator
+ * @param target_speed the speed to updtate to
+ * @return the current set speed of the actuator
  */
 float Actuator::update_speed(float target_speed) {
   return Actuator::set_speed(target_speed);
@@ -45,8 +48,8 @@ float Actuator::update_speed(float target_speed) {
 
 /**
  * Instructs the ODrive object to set given speed
- * 
- * Returns the speed that is set
+ * @param set_speed the speed to set
+ * @return the speed that is set
  */
 float Actuator::set_speed(float set_speed) {
   odrive->set_state(ACTUATOR_AXIS, 8);
@@ -58,8 +61,8 @@ float Actuator::set_speed(float set_speed) {
 // Readout Functions
 /**
  * Provides a readout passed through float array
- * 
- * Returns 0 as all member variables
+ * @param readout[5] array to be filled with readout
+ * @return 0 as all are member variables
 */
 int Actuator::get_readout(float readout[5]) {
   readout[0] = commanded_axis_state;

--- a/lib/Actuator/src/Actuator.h
+++ b/lib/Actuator/src/Actuator.h
@@ -21,7 +21,7 @@ class Actuator {
   int homing_error = 0;
   int homing_timer = 0;
   float current_speed = 0.0;
-  int commanded_axis_state;
+  int commanded_axis_state = -1;
   float commanded_axis_velocity = 0.0;
   // Constants
   int axis_number = ACTUATOR_AXIS;

--- a/lib/Constants/src/Constants.h
+++ b/lib/Constants/src/Constants.h
@@ -18,6 +18,11 @@ const int ESTOP_IN_PIN = 33;
 const int ESTOP_OUT_PIN = 32;
 const int LED_1_PIN = 28;
 const int LED_2_PIN = 29;
+const int BUTTON_UP_PIN = 28;
+const int BUTTON_LEFT_PIN = 29;
+const int BUTTON_CENTER_PIN = 30;
+const int BUTTON_RIGHT_PIN = 31;
+const int BUTTON_DOWN_PIN = 32;
 
 // Physical constants
 const float ROTATIONS_PER_ENGINE_COUNT = 1.0 / 16;

--- a/lib/Constants/src/Constants.h
+++ b/lib/Constants/src/Constants.h
@@ -31,10 +31,8 @@ const float SECONDARY_ROTATIONS_PER_WHEEL_COUNT =
 
 // Car-Indepenedent Constants
 const int LOG_LEVEL = 4;
-
-// Car-Independent Constants
-const int CONTROL_FUNCTION_INTERVAL = 1e5;  //microseconds
-const int ODRIVE_BAUD_RATE = 115200;        //hz
+const int CONTROL_FUNCTION_INTERVAL_US = 1e5;  //microseconds
+const int ODRIVE_BAUD_RATE = 115200;           //hz
 const int ACTUATOR_AXIS = 1;
 
 // Odrive constants
@@ -48,5 +46,12 @@ const int ODRIVE_VELOCITY_CONTROL_STATE = 8;
 
 // Unit conversions
 const int MICROSECONDS_PER_SECOND = 1e6;
+
+// GROND Software modes
+const int OPERATING_MODE = 0;
+const int SERIAL_DEBUG_MODE = 1;
+
+// Serial debug settings
+const int SERIAL_DEBUGGER_INTERVAL_US = 100000;
 
 #endif

--- a/lib/ODrive/src/OdriveCAN.cpp
+++ b/lib/ODrive/src/OdriveCAN.cpp
@@ -268,9 +268,15 @@ int OdriveCAN::clear_errors() {
 }
 
 // Setters
+/**
+ * Set odrive axis to requested state
+ * If the axis is already in the requested state, do nothing
+ * @return result of send_command
+*/
 int OdriveCAN::set_state(int axis, int state) {
-  //Serial.print("Switching State to ");
-  //Serial.println(state);
+  if (get_axis_state(axis) == state) {
+    return 0;
+  }
   uint8_t buf[8] = {0};
   memcpy(buf, &state, 4);
   return send_command(axis, CAN_SET_AXIS_REQUESTED_STATE, 0, buf);
@@ -278,7 +284,6 @@ int OdriveCAN::set_state(int axis, int state) {
 
 int OdriveCAN::set_axis_node_id(int axis, int axis_node_id) {
   uint8_t buf[8] = {0};
-  //memcpy(&axis_node_id, buf, 4);
   memcpy(buf, &axis_node_id, 4);
   return send_command(axis, CAN_SET_AXIS_NODE_ID, 0);
 }

--- a/lib/ODrive/src/OdriveCAN.cpp
+++ b/lib/ODrive/src/OdriveCAN.cpp
@@ -91,7 +91,7 @@ void OdriveCAN::parse_message(const CAN_message_t& msg) {
       break;
     case CAN_GET_VBUS_VOLTAGE:
       memcpy(&vbus_voltage, msg.buf, 4);
-      memcpy(&vbus_current, msg.buf, 4);
+      memcpy(&vbus_current, msg.buf + 4, 4);
       break;
   }
 }

--- a/lib/ODrive/src/OdriveCAN.cpp
+++ b/lib/ODrive/src/OdriveCAN.cpp
@@ -18,7 +18,7 @@ int OdriveCAN::send_command(int axis, int cmd_id, bool remote, uint8_t buf[8]) {
   if (axis != 0 && axis != 1) {
     return COMMAND_ERROR_INVALID_AXIS;
   }
-  
+
   if (cmd_id < 0x1 || 0x1b < cmd_id) {
     return COMMAND_ERROR_INVALID_COMMAND;
   }
@@ -100,8 +100,8 @@ void OdriveCAN::parse_message(const CAN_message_t& msg) {
 
 /**
  * Requests all information needed for a readout over CAN
- * 
- * Returns a sum of all the return values of the individual requests
+ * @param axis the odrive axis to request information from
+ * @return a sum of all the return values of the individual requests
 */
 int OdriveCAN::request_readout(int axis) {
   int result = 0;
@@ -148,9 +148,11 @@ int OdriveCAN::request_vbus_voltage() {
 
 // Getters
 /**
- * Get readout of ODRIVE state for certain axis, returned through reference
+ * Get readout of ODRIVE state
+ * @param axis the axis to get the readout from
+ * @param readout a float array to store the readout in
  * 
- * Retunrs 0 as all are member variables
+ * @return 0 as all are member variables
 */
 int OdriveCAN::get_readout(int axis, float readout[19]) {
   readout[0] = get_time_since_heartbeat_ms();
@@ -287,7 +289,7 @@ int OdriveCAN::set_controller_modes(int axis, int control_mode,
   //memcpy(&control_mode, buf, 4);
   //memcpy(&input_mode, buf + 4, 4);
   memcpy(buf, &control_mode, 4);
-  memcpy(buf+4, &input_mode, 4);
+  memcpy(buf + 4, &input_mode, 4);
   return send_command(axis, CAN_SET_CONTROLLER_MODES, 0);
 }
 
@@ -298,8 +300,8 @@ int OdriveCAN::set_input_pos(int axis, float input_pos, int16_t vel_ff,
   //memcpy(&vel_ff, buf + 4, 2);
   //memcpy(&torque_ff, buf + 6, 2);
   memcpy(buf, &input_pos, 4);
-  memcpy(buf+4, &vel_ff,  2);
-  memcpy(buf+6, &torque_ff,  2);
+  memcpy(buf + 4, &vel_ff, 2);
+  memcpy(buf + 6, &torque_ff, 2);
   return send_command(axis, CAN_SET_INPUT_POS, 0);
 }
 
@@ -309,8 +311,8 @@ int OdriveCAN::set_input_vel(int axis, float input_vel, float torque_ff) {
   //memcpy(&input_vel, buf, 4);
   //memcpy(&torque_ff, buf + 4, 4);
 
-  memcpy(buf, &input_vel,4);
-  memcpy(buf+4 , &torque_ff , 4);
+  memcpy(buf, &input_vel, 4);
+  memcpy(buf + 4, &torque_ff, 4);
   return send_command(axis, CAN_SET_INPUT_VEL, 0, buf);
 }
 
@@ -327,7 +329,7 @@ int OdriveCAN::set_limits(int axis, float current_limit, float vel_limit) {
   //memcpy(&current_limit, buf, 4);
   //memcpy(&vel_limit, buf + 4, 4);
   memcpy(buf, &current_limit, 4);
-  memcpy(buf+4, &vel_limit,  4);
+  memcpy(buf + 4, &vel_limit, 4);
   return send_command(axis, CAN_SET_LIMITS, 0);
 }
 
@@ -344,7 +346,7 @@ int OdriveCAN::set_traj_accel_limits(int axis, float traj_decel_limit,
   uint8_t buf[8] = {0};
   //memcpy(&traj_decel_limit, buf + 4, 4);
   //memcpy(&traj_accel_limit, buf, 4);
-  memcpy(buf+4, &traj_decel_limit, 4);
+  memcpy(buf + 4, &traj_decel_limit, 4);
   memcpy(buf, &traj_accel_limit, 4);
   return send_command(axis, CAN_SET_TRAJ_ACCEL_LIMITS, 0);
 }
@@ -373,11 +375,11 @@ int OdriveCAN::set_pos_gain(int axis, float pos_gain) {
 
 int OdriveCAN::set_vel_gains(int axis, float vel_gain,
                              float vel_integrator_gain) {
-  uint8_t buf[8] = {0}; 
+  uint8_t buf[8] = {0};
   //memcpy(&vel_gain, buf, 4);
   //memcpy(&vel_integrator_gain, buf + 4, 4);
 
-  memcpy(buf, &vel_gain,  4);
-  memcpy(buf+4, &vel_integrator_gain, 4);
+  memcpy(buf, &vel_gain, 4);
+  memcpy(buf + 4, &vel_integrator_gain, 4);
   return send_command(axis, CAN_SET_VEL_GAINS, 0);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -114,7 +114,7 @@ void control_function() {
              stop_us, eg_rpm, wl_rpm, current_eg_count, current_wl_count, error,
              velocity_command, odrive_can.get_voltage(),
              odrive_can.get_time_since_heartbeat_ms(),
-             odrive_can.get_shadow_count(1), can_error);
+             odrive_can.get_shadow_count(ACTUATOR_AXIS), can_error);
   log_file.close();
   log_file = SD.open(log_name.c_str(), FILE_WRITE);
 
@@ -123,9 +123,11 @@ void control_function() {
       "%d axis_state: %d axis_error: %d odrive_velocity_estimate: %f eg_rpm: "
       "%f vel_cmd: %f \n",
       millis(), current_eg_count, current_wl_count, odrive_can.get_voltage(),
-      odrive_can.get_time_since_heartbeat_ms(), odrive_can.get_shadow_count(1),
-      can_error, odrive_can.get_axis_state(1), odrive_can.get_axis_error(1),
-      odrive_can.get_vel_estimate(1), eg_rpm, velocity_command);
+      odrive_can.get_time_since_heartbeat_ms(),
+      odrive_can.get_shadow_count(ACTUATOR_AXIS), can_error,
+      odrive_can.get_axis_state(ACTUATOR_AXIS),
+      odrive_can.get_axis_error(ACTUATOR_AXIS),
+      odrive_can.get_vel_estimate(ACTUATOR_AXIS), eg_rpm, velocity_command);
 
   //need current state, current velocity,
 }
@@ -172,11 +174,11 @@ void setup() {
   Serial.print("Attaching interrupt mode " + String(kMode));
   last_exec_us = micros();
   switch (kMode) {
-    case 0:
-      odrive_can.set_state(1, 8);
+    case OPERATING_MODE:
+      odrive_can.set_state(ACTUATOR_AXIS, ODRIVE_VELOCITY_CONTROL_STATE);
       timer.begin(control_function, CONTROL_FUNCTION_INTERVAL_US);
       break;
-    case 1:
+    case SERIAL_DEBUG_MODE:
       timer.begin(serial_debugger, SERIAL_DEBUGGER_INTERVAL_US);
       break;
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -165,27 +165,17 @@ void control_function() {
       odrive_can.get_shadow_count(ACTUATOR_AXIS), can_error, velocity_command,
       flushed);
   log_file.printf(
-      "ms: %d, voltage: %.2f, heartbeat: %d, enc: %d, can_error: %d, vel_cmd: "
-      "%.2f, flushed: %d\n",
-      millis(), odrive_can.get_voltage(),
-      odrive_can.get_time_since_heartbeat_ms(),
-      odrive_can.get_shadow_count(ACTUATOR_AXIS), can_error, velocity_command,
-      flushed);
-  /*
-  Serial.printf(
-      "ms: %d ec: %d wc: %d voltage: %.2f heartbeat: %d enc: %d can_error: "
-      "%d axis_state: %d axis_error: %d odrive_velocity_estimate: %f "
-      "eg_rpm: "
-      "%f vel_cmd: %f (flush: %d pressed: %d\n",
-      millis(), current_eg_count, current_wl_count, odrive_can.get_voltage(),
-      odrive_can.get_time_since_heartbeat_ms(),
-      odrive_can.get_shadow_count(ACTUATOR_AXIS), can_error,
-      odrive_can.get_axis_state(ACTUATOR_AXIS),
+      "%d, %.2f, %d, %.2f, %.2f, %.2f, %.2f, %d, %d, %d, %.5f, %d, %d, %d, "
+      "%.5f, %d, %d, %.5f, %d, %d, %d\n",
+      dt_us, odrive_can.get_voltage(), odrive_can.get_time_since_heartbeat_ms(),
+      wl_rpm, eg_rpm, TARGET_RPM, velocity_command,
+      odrive_can.get_shadow_count(ACTUATOR_AXIS), -1, -1,
+      odrive_can.get_iq_measured(ACTUATOR_AXIS), flushed, current_wl_count,
+      current_eg_count, odrive_can.get_iq_setpoint(ACTUATOR_AXIS), start_us,
+      stop_us, odrive_can.get_current(),
       odrive_can.get_axis_error(ACTUATOR_AXIS),
-      odrive_can.get_vel_estimate(ACTUATOR_AXIS), eg_rpm, velocity_command,
-      last_log_flush == 1, pressed);
-      */
-
+      odrive_can.get_motor_error(ACTUATOR_AXIS),
+      odrive_can.get_encoder_error(ACTUATOR_AXIS));
   pressed = false;
   flushed = false;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,14 +11,7 @@
 // Classes
 #include <Actuator.h>
 #include <Constants.h>
-#include <Odrive.h>
 #include <OdriveCAN.h>
-
-#define BUTTON_UP 28
-#define BUTTON_LEFT 29
-#define BUTTON_CENTER 30
-#define BUTTON_RIGHT 31
-#define BUTTON_DOWN 32
 
 // Startup Settings
 static constexpr int kMode = OPERATING_MODE;
@@ -30,61 +23,17 @@ OdriveCAN odrive_can;
 Actuator actuator(&odrive_can);
 IntervalTimer timer;
 File log_file;
-
-// File-Scope Variable Declarations
 String log_name;
-
-// Geartooth counts
-volatile unsigned long eg_count = 0;
-volatile unsigned long wl_count = 0;
-
-// Control Function Variables
-u_int32_t last_exec_us;
-long int last_eg_count = 0;
-long int last_wl_count = 0;
 
 // Parses CAN messages when received
 void odrive_can_parse(const CAN_message_t& msg) {
   odrive_can.parse_message(msg);
 }
 
-void serial_debugger() {
-  u_int32_t start_us = micros();
-  u_int32_t dt_us = start_us - last_exec_us;
-
-  noInterrupts();
-  long current_eg_count = eg_count;
-  long current_wl_count = wl_count;
-  interrupts();
-
-  // First, calculate rpms
-  float eg_rpm = (current_eg_count - last_eg_count) *
-                 ROTATIONS_PER_ENGINE_COUNT / dt_us * MICROSECONDS_PER_SECOND *
-                 60.0;
-  float wl_rpm = (current_wl_count - last_wl_count) *
-                 ROTATIONS_PER_WHEEL_COUNT / dt_us * MICROSECONDS_PER_SECOND *
-                 60.0;
-
-  last_eg_count = current_eg_count;
-  last_wl_count = current_wl_count;
-  last_exec_us = start_us;
-
-  Serial.printf("ms: %d ec: %d wc: %d ec_rpm: %f wc_rpm %f\n", millis(),
-                current_eg_count, current_wl_count, eg_rpm, wl_rpm);
-  // int can_error = 0;
-  // can_error = (can_error << 1) & odrive_can.request_vbus_voltage();
-  // can_error = (can_error << 1) & odrive_can.request_motor_error(1);
-  // can_error = (can_error << 1) & odrive_can.request_encoder_count(1);
-  // Serial.printf(
-  //     "ms: %d ec: %d wc: %d voltage: %.2f heartbeat: %d enc: %d can_error: "
-  //     "%d\n",
-  //     millis(), current_eg_count, current_wl_count, odrive_can.get_voltage(),
-  //     odrive_can.get_time_since_heartbeat_ms(), odrive_can.get_shadow_count(1),
-  //     can_error);
-}
-
-// Control Function ඞ
-
+// Control Function Variables
+u_int32_t last_exec_us;
+long int last_eg_count = 0;
+long int last_wl_count = 0;
 float desired_speed = 0;
 int last_left_button = 0;
 int last_right_button = 0;
@@ -92,6 +41,12 @@ int cycles_per_log_flush = 10;
 int last_log_flush = 0;
 bool pressed = false;
 bool flushed = false;
+
+// Geartooth counts
+volatile unsigned long eg_count = 0;
+volatile unsigned long wl_count = 0;
+
+//ඞ
 void control_function() {
   u_int32_t start_us = micros();
   u_int32_t dt_us = start_us - last_exec_us;
@@ -116,10 +71,10 @@ void control_function() {
   float error = TARGET_RPM - eg_rpm;
   float velocity_command = error * PROPORTIONAL_GAIN;
 
-  int left_button = !digitalRead(BUTTON_LEFT);
-  int right_button = !digitalRead(BUTTON_RIGHT);
-  int center_button = !digitalRead(BUTTON_CENTER);
-  int down_button = !digitalRead(BUTTON_DOWN);
+  int left_button = !digitalRead(BUTTON_LEFT_PIN);
+  int right_button = !digitalRead(BUTTON_RIGHT_PIN);
+  int center_button = !digitalRead(BUTTON_CENTER_PIN);
+  int down_button = !digitalRead(BUTTON_DOWN_PIN);
   if (left_button && !last_left_button) {
     desired_speed -= 1;
     pressed = true;
@@ -164,6 +119,7 @@ void control_function() {
       odrive_can.get_time_since_heartbeat_ms(),
       odrive_can.get_shadow_count(ACTUATOR_AXIS), can_error, velocity_command,
       flushed);
+
   log_file.printf(
       "%d, %.2f, %d, %.2f, %.2f, %.2f, %.2f, %d, %d, %d, %.5f, %d, %d, %d, "
       "%.5f, %d, %d, %.5f, %d, %d, %d\n",
@@ -176,16 +132,41 @@ void control_function() {
       odrive_can.get_axis_error(ACTUATOR_AXIS),
       odrive_can.get_motor_error(ACTUATOR_AXIS),
       odrive_can.get_encoder_error(ACTUATOR_AXIS));
+
   pressed = false;
   flushed = false;
 }
 
+void serial_debugger() {
+  u_int32_t start_us = micros();
+  u_int32_t dt_us = start_us - last_exec_us;
+
+  noInterrupts();
+  long current_eg_count = eg_count;
+  long current_wl_count = wl_count;
+  interrupts();
+
+  float eg_rpm = (current_eg_count - last_eg_count) *
+                 ROTATIONS_PER_ENGINE_COUNT / dt_us * MICROSECONDS_PER_SECOND *
+                 60.0;
+  float wl_rpm = (current_wl_count - last_wl_count) *
+                 ROTATIONS_PER_WHEEL_COUNT / dt_us * MICROSECONDS_PER_SECOND *
+                 60.0;
+
+  last_eg_count = current_eg_count;
+  last_wl_count = current_wl_count;
+  last_exec_us = start_us;
+
+  Serial.printf("ms: %d ec: %d wc: %d ec_rpm: %f wc_rpm %f\n", millis(),
+                current_eg_count, current_wl_count, eg_rpm, wl_rpm);
+}
+
 void setup() {
-  pinMode(BUTTON_UP, INPUT);
-  pinMode(BUTTON_DOWN, INPUT);
-  pinMode(BUTTON_LEFT, INPUT);
-  pinMode(BUTTON_RIGHT, INPUT);
-  pinMode(BUTTON_CENTER, INPUT);
+  pinMode(BUTTON_UP_PIN, INPUT);
+  pinMode(BUTTON_DOWN_PIN, INPUT);
+  pinMode(BUTTON_LEFT_PIN, INPUT);
+  pinMode(BUTTON_RIGHT_PIN, INPUT);
+  pinMode(BUTTON_CENTER_PIN, INPUT);
 
   if (kWaitSerial) {
     while (!Serial) {}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -176,17 +176,13 @@ void setup() {
   Serial.print("Attaching timer interrupt: ");
   last_exec_us = micros();
   switch (kMode) {
-    switch (kMode) {
-      case 0:
-        odrive_can.set_state(1, 8);
-        timer.begin(control_function, CONTROL_FUNCTION_INTERVAL);
-        break;
-      case 1:
-        timer.begin(serial_debugger, kSerialDebuggerIntervalUs);
-        break;
-        timer.begin(serial_debugger, kSerialDebuggerIntervalUs);
-        break;
-    }
+    case 0:
+      odrive_can.set_state(1, 8);
+      timer.begin(control_function, CONTROL_FUNCTION_INTERVAL);
+      break;
+    case 1:
+      timer.begin(serial_debugger, kSerialDebuggerIntervalUs);
+      break;
   }
 }
 void loop() {}


### PR DESCRIPTION
Grant discovered that delays due to saving to the SD card led to the code being unable to send messages over CAN.
The bug was recreated and tested, and found that a delay ~14ms is enough to kill it.
As a patchwork solution, the CAN connection is soft reset each time the SD buffer is dumped, avoiding the issue.
Also, the SD card now uses DMA through SDFat, which reduced flush times from ~14ms to ~5ms